### PR TITLE
fix: exclude pull requests from issue count

### DIFF
--- a/src/wb-git-status.sh
+++ b/src/wb-git-status.sh
@@ -48,7 +48,7 @@ if [[ $PROVIDER == "github.com" ]]; then
   fi
   
   # Fetch issues with labels and type fields
-  RES=$(gh api "repos/{owner}/{repo}/issues?$QUERY" | jq '[.[] | {labels, type}]')
+  RES=$(gh api "repos/{owner}/{repo}/issues?$QUERY" | jq '[.[] | select(.pull_request == null) | {labels, type}]')
   
   # Count total issues and bugs (supporting both labels and issue types)
   ISSUE_COUNT=$(echo "$RES" | jq 'length' | bc)


### PR DESCRIPTION
## Summary
Fixes inflated issue counts by excluding pull requests from the count.

## Problem
The GitHub API `/issues` endpoint returns both issues AND pull requests, which was causing the widget to show incorrect counts (e.g., showing 29 items when there were only 12 actual issues).

## Solution
Added a filter to exclude items that have a `pull_request` field, ensuring we only count actual issues.

## Test
- Before: API returns both issues and PRs
- After: Only actual issues are counted

🤖 Generated with [Claude Code](https://claude.ai/code)