### PR TITLE
fix: Correct untracked file count to match git status

### DIFF
--- a/src/git-status.sh
+++ b/src/git-status.sh
@@ -35,7 +35,7 @@ if [[ $STATUS -ne 0 ]]; then
   SYNC_MODE=1
 fi
 
-UNTRACKED_COUNT="$(git ls-files --other --directory --exclude-standard | wc -l | bc)"
+UNTRACKED_COUNT="$(git ls-files --other --exclude-standard | wc -l | bc)"
 
 if [[ $CHANGED_COUNT -gt 0 ]]; then
   STATUS_CHANGED="${RESET}#[fg=${THEME[yellow]},bg=${THEME[background]},bold] ${CHANGED_COUNT} "


### PR DESCRIPTION
> [!NOTE] 
> Duplicate of PR #125 from `apt-get-coke:fix/untracked-files-count`

## Summary
This PR fixes the untracked file count in the git status widget to match the standard `git status` behavior.

## The Problem
The widget uses `git ls-files --other --directory --exclude-standard` which creates a confusing contradiction:

- It counts directories containing only ignored files as "untracked"
- But these directories can never actually be tracked (they contain only gitignored files)
- This results in the widget showing "2 untracked" while `git status` shows "working tree clean"

This is semantically incorrect - calling something "untracked" implies it _could_ be tracked, but these directories cannot be.

## Solution
Changed the command to `git ls-files --other --exclude-standard` (removed the --directory flag) to match standard git behavior.

## Why This Matters
1. **Consistency**: The widget now matches what `git status` reports
2. **Clear Semantics**: "Untracked" now means "can be added to git" (as users expect)
3. **Reduced Confusion**: No more discrepancy between git status and the widget

## Example
A repository with this structure:
```
.gitignore (contains: config/*, data/*)
config/
  └── service.conf (ignored)
data/
  └── cache.db (ignored)
```
**Before:** Widget shows "2 untracked" (the directories, which can't actually be tracked)
**After:** Widget shows "0 untracked" (matches git status)

## Testing
Tested on repositories with complex `.gitignore` patterns that create empty tracked directories containing only ignored files. The fix correctly shows 0 untracked files when `git status` reports a clean working tree.